### PR TITLE
Remove Saymedia references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This allows you to manage buildkite pipelines with Terraform.
 
 Run
 ```bash
-go get github.com/saymedia/terraform-buildkite/terraform-provider-buildkite
-go install github.com/saymedia/terraform-buildkite/terraform-provider-buildkite
+go get github.com/buildkite/terraform-buildkite/terraform-provider-buildkite
+go install github.com/buildkite/terraform-buildkite/terraform-provider-buildkite
 ```
 Which gives you a `terraform-provider-buildkite` in `$GOPATH/bin`.
 
@@ -55,7 +55,7 @@ terraform import buildkite_pipeline.my_name my-pipeline-slug
 To do local development you will most likely be working in a Github fork of the repository. After creating your fork
 you can add it as a remote on your local repository in GOPATH:
 
-* `cd $GOPATH/src/github.com/saymedia/terraform-buildkite`
+* `cd $GOPATH/src/github.com/buildkite/terraform-buildkite`
 * `git remote add mine git@github.com:yourname/terraform-buildkite`
 * `git checkout -b yourbranch`
 * `git push -u mine yourbranch`
@@ -64,7 +64,7 @@ After this you should be able to `git push` to your fork, and eventually open a 
 
 You can build like this:
 
-* `go install github.com/saymedia/terraform-buildkite/terraform-provider-buildkite`
+* `go install github.com/buildkite/terraform-buildkite/terraform-provider-buildkite`
 
 This should produce a file at `$GOPATH/bin/terraform-provider-buildkite`. To use this with Terraform you'll need to move that binary to the [third-party plugins direcory](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin) to help Terraform find this file.
 

--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ go get github.com/mitchellh/gox
 # there are deb packages for those.
 
 # Build the provider
-gox -arch="$GOX_ARCH" -os="$GOX_OS" -output="$GOX_MAIN_TEMPLATE" github.com/saymedia/terraform-buildkite/terraform-provider-buildkite
+gox -arch="$GOX_ARCH" -os="$GOX_OS" -output="$GOX_MAIN_TEMPLATE" github.com/buildkite/terraform-buildkite/terraform-provider-buildkite
 
 # ZZZZZZZZZZZZZZZZZZZZIPPIT
 echo "--- Build done"

--- a/buildkite/resource_pipeline_test.go
+++ b/buildkite/resource_pipeline_test.go
@@ -190,7 +190,7 @@ resource "buildkite_pipeline" "test_beanstalk" {
 const testAccPipeline_basicGithub = `
 resource "buildkite_pipeline" "test_github" {
   name = "tf-acc-basic-github"
-  repository = "git@github.com:saymedia/terraform-provider-buildkite.git"
+  repository = "git@github.com:buildkite/terraform-provider-buildkite.git"
 
   step {
     type = "script"

--- a/terraform-provider-buildkite/main.go
+++ b/terraform-provider-buildkite/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/saymedia/terraform-buildkite/buildkite"
+	"github.com/buildkite/terraform-buildkite/buildkite"
 )
 
 func main() {


### PR DESCRIPTION
## Context
I am assuming that Buildkite took over the maintenance of this Terraform provider from Saymedia. 

Thus, I am removing any reference to the parent repository in:
 
- README.md
- Go code (imports, strings, etc)
- Build scripts

## Motivation
AFAIK, there aren't available releases for this provider which forces consumers to build it from its source code. This is fine since the project is still in WIP mode. However, due to the existing import paths in `main.go`, consumers end up checking out and building the parent repository's code instead of this one's which seems incorrect and, potentially, harmful.

## Proposed solution
To update any reference to the parent repository with the local corresponding one.